### PR TITLE
[DOCS] Add error codes in docs

### DIFF
--- a/src/documents/android/store/Store_Events.html.md
+++ b/src/documents/android/store/Store_Events.html.md
@@ -325,7 +325,11 @@ This event is triggered an unexpected error occurs in the Store.
 @Subscribe
 public void onUnexpectedStoreError(UnexpectedStoreErrorEvent unexpectedStoreErrorEvent) {
   // unexpectedStoreErrorEvent contains:
-  //   errorCode - code of the error
+  // errorCode - code of the error:  
+  //    VERIFICATION_FAIL - something is going wrong while SOOMLA tried to verify purchase.
+  //    VERIFICATION_TIMEOUT - app didn't receive validation response from server in time. Please, try again later. 
+  //    PURCHASE_FAIL - something is going wrong while SOOMLA tried to make purchase.
+  //    GENERAL - other types of error. See details in app logs.
 
   // ... your game specific implementation here ...
 }

--- a/src/documents/cocos2dx/cpp/store/Store_Events.html.md
+++ b/src/documents/cocos2dx/cpp/store/Store_Events.html.md
@@ -435,6 +435,12 @@ void Example::onBillingNotSupported(EventCustom *event) {
 
 This event is triggered an unexpected error occurs in the Store.
 
+Available error codes:
+ - VERIFICATION_TIMEOUT(1) - app didn't receive validation response from server in time. Please, try again later.
+ - VERIFICATION_FAIL(2) - something is going wrong while SOOMLA tried to verify purchase.  
+ - PURCHASE_FAIL(3) - something is going wrong while SOOMLA tried to make purchase.
+ - GENERAL(0) - other types of error. See details in app logs.
+
 ```cpp
 Director::getInstance()->getEventDispatcher()->addCustomEventListener(CCStoreConsts::EVENT_UNEXPECTED_STORE_ERROR, CC_CALLBACK_1(Example::onUnexpectedErrorInStore, this));
 

--- a/src/documents/cocos2dx/js/store/Store_Events.html.md
+++ b/src/documents/cocos2dx/js/store/Store_Events.html.md
@@ -341,6 +341,12 @@ this.onBillingNotSupported = function () {
 
 This event is triggered an unexpected error occurs in the Store.
 
+Available error codes:
+ - VERIFICATION_TIMEOUT(1) - app didn't receive validation response from server in time. Please, try again later.
+ - VERIFICATION_FAIL(2) - something is going wrong while SOOMLA tried to verify purchase.  
+ - PURCHASE_FAIL(3) - something is going wrong while SOOMLA tried to make purchase.
+ - GENERAL(0) - other types of error. See details in app logs.
+
 ```js
 Soomla.addHandler(Soomla.StoreConsts.EVENT_UNEXPECTED_STORE_ERROR, this.onUnexpectedErrorInStore, this);
 

--- a/src/documents/ios/store/Store_Events.html.md
+++ b/src/documents/ios/store/Store_Events.html.md
@@ -387,6 +387,10 @@ The event `EVENT_UNEXPECTED_ERROR_IN_STORE` is triggered an unexpected error occ
 - (void)unexpectedStoreError:(NSNotification*)notification {
   // notification's userInfo contains the following keys:
   // DICT_ELEMENT_ERROR_CODE = Numeric error code
+  //    ERR_VERIFICATION_FAIL - something is going wrong while SOOMLA tried to verify purchase.
+  //    ERR_VERIFICATION_TIMEOUT - app didn't receive validation response from server in time. Please, try again later. 
+  //    ERR_PURCHASE_FAIL - something is going wrong while SOOMLA tried to make purchase.
+  //    ERR_GENERAL - other types of error. See details in app logs.
 
   // ... your game specific implementation here ...
 }

--- a/src/documents/unity/store/Store_Events.html.md
+++ b/src/documents/unity/store/Store_Events.html.md
@@ -319,6 +319,11 @@ public void onBillingNotSupported() {
 
 ### OnUnexpectedStoreError
 
+Available error codes:
+ - VERIFICATION_TIMEOUT(1) - app didn't receive validation response from server in time. Please, try again later.
+ - VERIFICATION_FAIL(2) - something is going wrong while SOOMLA tried to verify purchase.  
+ - PURCHASE_FAIL(3) - something is going wrong while SOOMLA tried to make purchase.
+ - GENERAL(0) - other types of error. See details in app logs.
 
 ``` cs
 StoreEvents.OnUnexpectedStoreError += onUnexpectedStoreError;


### PR DESCRIPTION
done
I placed into Unity and Cocos refs name and number of error code because this platforms doesn't have mnemonical names for error codes
